### PR TITLE
fix: add docker profile to JwtDecoder bean

### DIFF
--- a/src/main/java/com/accountabilityatlas/moderationservice/config/SecurityConfig.java
+++ b/src/main/java/com/accountabilityatlas/moderationservice/config/SecurityConfig.java
@@ -43,7 +43,7 @@ public class SecurityConfig {
   }
 
   @Bean
-  @Profile("local")
+  @Profile({"local", "docker"})
   public JwtDecoder localJwtDecoder() {
     return token ->
         new Jwt(


### PR DESCRIPTION
## Summary

- Add `docker` to the `@Profile` annotation on `JwtDecoder` bean

Fixes #8

## Test plan

- [x] Rebuild Docker image with `./gradlew jibDockerBuild`
- [x] Verify service starts successfully with `SPRING_PROFILES_ACTIVE=docker`

🤖 Generated with [Claude Code](https://claude.ai/code)