### PR TITLE
feat: add SECURITY participant type

### DIFF
--- a/docs/api-specification.yaml
+++ b/docs/api-specification.yaml
@@ -857,7 +857,7 @@ components:
           type: array
           items:
             type: string
-            enum: [POLICE, GOVERNMENT, BUSINESS, CITIZEN]
+            enum: [POLICE, GOVERNMENT, BUSINESS, CITIZEN, SECURITY]
           description: Types of participants in the encounter
         videoDate:
           type: string
@@ -866,7 +866,7 @@ components:
           description: When the incident occurred
       examples:
         - amendments: ["FIRST", "FOURTH"]
-          participants: ["POLICE", "CITIZEN"]
+          participants: ["POLICE", "SECURITY"]
           videoDate: "2025-01-15"
 
     AddLocationRequest:


### PR DESCRIPTION
## Summary
- Add `SECURITY` to inline participants enum in OpenAPI spec
- Update example to use SECURITY

Closes #25

Part of cross-cutting change: [AccountabilityAtlas#46](https://github.com/kelleyglenn/AccountabilityAtlas/issues/46)

## Test plan
- [x] `./gradlew check` passes (generated code rebuilds with new enum)
- [x] Full stack deployed and verified (107 API + 138 E2E tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)