### PR TITLE
feat: add production Spring profile

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,9 @@
+spring:
+  flyway:
+    locations:
+      - classpath:db/migration
+
+logging:
+  level:
+    com.accountabilityatlas: INFO
+    org.springframework.security: WARN


### PR DESCRIPTION
## Summary

- Add `application-prod.yml` with production Flyway locations (no dev seed data) and INFO/WARN logging

Part of the AWS demo deployment effort (AccountabilityAtlas#54).

## Test plan

- [ ] Service starts with `SPRING_PROFILES_ACTIVE=prod`
- [ ] Flyway only runs migration scripts (no dev seed data)
- [ ] No dev-level debug logging in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)