### PR TITLE
fix: use env var placeholders for inter-service URLs

### DIFF
--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -10,4 +10,4 @@ app:
   video-service:
     base-url: http://video-service:8082
   user-service:
-    base-url: http://user-service:8080
+    base-url: http://user-service:8081

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -1,13 +1,9 @@
 spring:
   datasource:
     url: jdbc:postgresql://postgres:5432/moderation_service
+    username: moderation_service
+    password: local_dev
   cloud:
     aws:
       sqs:
         endpoint: http://localstack:4566
-
-app:
-  video-service:
-    base-url: http://video-service:8082
-  user-service:
-    base-url: http://user-service:8081

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,9 +1,8 @@
 spring:
-  security:
-    oauth2:
-      resourceserver:
-        jwt:
-          issuer-uri: http://localhost:8080
+  datasource:
+    url: jdbc:postgresql://localhost:5432/moderation_service
+    username: moderation_service
+    password: local_dev
   cloud:
     aws:
       sqs:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,28 +1,31 @@
+server:
+  port: 8085
+
 spring:
   application:
     name: moderation-service
-
-  datasource:
-    url: jdbc:postgresql://localhost:5432/moderation_service
-    username: moderation_service
-    password: local_dev
-    driver-class-name: org.postgresql.Driver
-
   jpa:
     hibernate:
       ddl-auto: validate
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect
         default_schema: moderation
     open-in-view: false
-
   flyway:
     enabled: true
     schemas:
       - moderation
-    default-schema: moderation
-
+    locations:
+      - classpath:db/migration
+  jackson:
+    default-property-inclusion: non_null
+    serialization:
+      write-dates-as-timestamps: false
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          jwk-set-uri: ${USER_SERVICE_JWKS_URL:http://localhost:8081/.well-known/jwks.json}
   cloud:
     aws:
       region:
@@ -31,17 +34,18 @@ spring:
         access-key: ${AWS_ACCESS_KEY_ID:test}
         secret-key: ${AWS_SECRET_ACCESS_KEY:test}
 
-server:
-  port: 8085
-
 management:
   endpoints:
     web:
       exposure:
-        include: health,info,metrics
+        include: health,info
   endpoint:
     health:
-      show-details: when_authorized
+      show-details: when-authorized
+
+logging:
+  level:
+    com.accountabilityatlas: DEBUG
 
 app:
   sqs:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -50,6 +50,6 @@ app:
     moderation-events-queue: moderation-events
     search-moderation-events-queue: search-moderation-events
   video-service:
-    base-url: http://localhost:8082
+    base-url: ${VIDEO_SERVICE_URL:http://localhost:8082}
   user-service:
-    base-url: http://localhost:8080
+    base-url: ${USER_SERVICE_URL:http://localhost:8081}

--- a/src/test/java/com/accountabilityatlas/moderationservice/web/ModerationQueueControllerTest.java
+++ b/src/test/java/com/accountabilityatlas/moderationservice/web/ModerationQueueControllerTest.java
@@ -265,7 +265,7 @@ class ModerationQueueControllerTest {
                 .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_MODERATOR"))))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.pending").value(0))
-        .andExpect(jsonPath("$.avgReviewTimeMinutes").isEmpty());
+        .andExpect(jsonPath("$.avgReviewTimeMinutes").doesNotExist());
   }
 
   // ============================================


### PR DESCRIPTION
## Summary
- Replace hardcoded `localhost` URLs with `${ENV_VAR:default}` placeholders for video-service and user-service in `application.yml`
- Fix user-service default port from 8080 (gateway) to 8081 (direct) in both `application.yml` and `application-docker.yml`
- Matches the env var pattern already used by video-service and search-service

### Config standardization (kelleyglenn/AccountabilityAtlas#95)
- Remove datasource from base config; add to profile-specific files (local, docker)
- Remove redundant `driver-class-name`, Hibernate dialect, flyway `default-schema`
- Add flyway locations, Jackson `non_null` + `write-dates-as-timestamps: false`
- Add `jwk-set-uri` with `${USER_SERVICE_JWKS_URL:...}` env var placeholder
- Fix management: remove `metrics` exposure, `when_authorized` → `when-authorized`
- Add base logging level for `com.accountabilityatlas`
- Remove dead `issuer-uri` from local profile
- Remove inter-service URL overrides from docker profile (env vars handle this)
- Update test assertion for `non_null` serialization behavior

Closes kelleyglenn/AccountabilityAtlas#93
Closes kelleyglenn/AccountabilityAtlas#95

## Test plan
- [x] Deploy moderation-service: `./scripts/deploy.sh moderation-service`
- [x] Run full integration tests: `cd AcctAtlas-integration-tests && npm run test:all` (119 API + 204 E2E passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)